### PR TITLE
Implement TwoHot distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Note: The code is being developed on Linux, and out of the box it works on Linux
 
 ## TODO
 
-- TwoHot loss isn't implemented yet with rewardModel and critic. I made an attempt and wrote neat code for it, but it didn't work and I'm out of ideas on how to proceed, so that's yet to be finished. For now, rewardModel and critic use normal distribution.
 - Discrete actions. That will be easy, just a few lines of code when I'll start solving more environments.
 - Add vector observations encoder and decoder.
 - Reconstruction loss is huge (11k), messing up graphs' axis scale. But graphs are only for debugging, so it's not a priority.

--- a/distributions.py
+++ b/distributions.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn.functional as F
+import utils
+
+
+class TwoHotCategoricalStraightThrough(torch.distributions.Distribution):
+    def __init__(self, logits: torch.Tensor, bins: int = 255, low: float = -20.0, high: float = 20.0):
+        super().__init__(validate_args=False)
+        self.logits = logits
+        self.bin_centers = torch.linspace(low, high, bins, device=logits.device)
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        value = utils.symlog(value).clamp(self.bin_centers[0], self.bin_centers[-1])
+        indices = ((value - self.bin_centers[0]) / (self.bin_centers[1] - self.bin_centers[0])).clamp(0, len(self.bin_centers) - 1)
+
+        lower = indices.floor().long().unsqueeze(-1)
+        upper = indices.ceil().long().unsqueeze(-1)
+        alpha = (indices - lower.squeeze(-1)).unsqueeze(-1)
+
+        probs = F.softmax(self.logits, dim=-1)
+        return torch.log((1 - alpha) * probs.gather(-1, lower) + alpha * probs.gather(-1, upper)).squeeze(-1)
+
+    @property
+    def mean(self) -> torch.Tensor:
+        return utils.symexp((F.softmax(self.logits, dim=-1) * self.bin_centers).sum(-1, keepdim=True))
+

--- a/networks.py
+++ b/networks.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Normal, Bernoulli, Independent, OneHotCategoricalStraightThrough
+from distributions import TwoHotCategoricalStraightThrough
 from torch.distributions.utils import probs_to_logits
 from utils import sequentialModel1D
 
@@ -62,14 +63,20 @@ class PosteriorNet(nn.Module):
 
 
 class RewardModel(nn.Module):
-    def __init__(self, inputSize, config):
+    def __init__(self, inputSize, config, bins: int = 255):
         super().__init__()
         self.config = config
-        self.network = sequentialModel1D(inputSize, [self.config.hiddenSize]*self.config.numLayers, 2, self.config.activation)
+        self.bins = bins
+        self.network = sequentialModel1D(
+            inputSize,
+            [self.config.hiddenSize] * self.config.numLayers,
+            self.bins,
+            self.config.activation,
+        )
 
     def forward(self, x):
-        mean, logStd = self.network(x).chunk(2, dim=-1)
-        return Normal(mean.squeeze(-1), torch.exp(logStd).squeeze(-1))
+        logits = self.network(x)
+        return TwoHotCategoricalStraightThrough(logits, bins=self.bins)
 
 
 class ContinueModel(nn.Module):
@@ -151,11 +158,17 @@ class Actor(nn.Module):
 
 
 class Critic(nn.Module):
-    def __init__(self, inputSize, config):
+    def __init__(self, inputSize, config, bins: int = 255):
         super().__init__()
         self.config = config
-        self.network = sequentialModel1D(inputSize, [self.config.hiddenSize]*self.config.numLayers, 2, self.config.activation)
+        self.bins = bins
+        self.network = sequentialModel1D(
+            inputSize,
+            [self.config.hiddenSize] * self.config.numLayers,
+            self.bins,
+            self.config.activation,
+        )
 
     def forward(self, x):
-        mean, logStd = self.network(x).chunk(2, dim=-1)
-        return Normal(mean.squeeze(-1), torch.exp(logStd).squeeze(-1))
+        logits = self.network(x)
+        return TwoHotCategoricalStraightThrough(logits, bins=self.bins)

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,14 @@ import pandas as pd
 import plotly.graph_objects as pgo
 
 
+def symlog(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * torch.log1p(torch.abs(x))
+
+
+def symexp(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * (torch.exp(torch.abs(x)) - 1)
+
+
 def seedEverything(seed):
     random.seed(seed)
     np.random.seed(seed)


### PR DESCRIPTION
## Summary
- revert previous attempt at TwoHot
- implement `TwoHotCategoricalStraightThrough` distribution
- expose symlog helpers in utils
- use the new distribution in `RewardModel` and `Critic`
- update README TODO

## Testing
- `python -m py_compile distributions.py networks.py dreamer.py utils.py buffer.py envs.py main.py`
- `python - <<'PY'` *(failed: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684ffb34f2c08322b60e62b49c977b5d